### PR TITLE
Fix price format in cars.json

### DIFF
--- a/api/cars.json
+++ b/api/cars.json
@@ -29,7 +29,7 @@
     "year": "2006",
     "transmission": "Automatic",
     "drivetrain": "Rear-wheel drive",
-    "price": "11.000",
+    "price": "11,000",
     "bodyStyle": "Sedan",
     "images": [
       "images/imgJson/lexus/ls4302006/lexusls4302006.jpg",


### PR DESCRIPTION
## Summary
- corrected the Lexus LS 430 price string to match other entries

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6840ad25c7308323a1863ef492fedac5